### PR TITLE
[ClassLoader] Use symfony/polyfill-apcu

### DIFF
--- a/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
@@ -71,7 +71,7 @@ class ApcUniversalClassLoader extends UniversalClassLoader
      */
     public function __construct($prefix)
     {
-        if (!extension_loaded('apc')) {
+        if (!function_exists('apcu_fetch')) {
             throw new \RuntimeException('Unable to use ApcUniversalClassLoader as APC is not enabled.');
         }
 
@@ -87,8 +87,8 @@ class ApcUniversalClassLoader extends UniversalClassLoader
      */
     public function findFile($class)
     {
-        if (false === $file = apc_fetch($this->prefix.$class)) {
-            apc_store($this->prefix.$class, $file = parent::findFile($class));
+        if (false === $file = apcu_fetch($this->prefix.$class)) {
+            apcu_store($this->prefix.$class, $file = parent::findFile($class));
         }
 
         return $file;

--- a/src/Symfony/Component/ClassLoader/Tests/ApcUniversalClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ApcUniversalClassLoaderTest.php
@@ -14,14 +14,14 @@ namespace Symfony\Component\ClassLoader\Tests;
 use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
 
 /**
- * @requires extension apc
+ *
  */
 class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
         if (ini_get('apc.enabled') && ini_get('apc.enable_cli')) {
-            apc_clear_cache('user');
+            apcu_clear_cache();
         } else {
             $this->markTestSkipped('APC is not enabled.');
         }
@@ -30,7 +30,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         if (ini_get('apc.enabled') && ini_get('apc.enable_cli')) {
-            apc_clear_cache('user');
+            apcu_clear_cache();
         }
     }
 
@@ -39,7 +39,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Apc\Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
 
-        $this->assertEquals($loader->findFile('\Apc\Namespaced\FooBar'), apc_fetch('test.prefix.\Apc\Namespaced\FooBar'), '__construct() takes a prefix as its first argument');
+        $this->assertEquals($loader->findFile('\Apc\Namespaced\FooBar'), apcu_fetch('test.prefix.\Apc\Namespaced\FooBar'), '__construct() takes a prefix as its first argument');
     }
 
    /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

[#17358] updated ApcClassLoader to use polyfill-apcu, but not ApcUniversalClassLoader

2.7 / 2.8 tests are in LegacyApcUniversalClassLoaderTest
